### PR TITLE
Java 7 and Java 8 improvements

### DIFF
--- a/src/main/javacc/Java1.1.jj
+++ b/src/main/javacc/Java1.1.jj
@@ -2997,7 +2997,7 @@ void TryWithResources() :
 {}
 {
 //  LocalVariableDeclaration() [ ";" ]
-  LocalVariableDeclaration() ( ";" LocalVariableDeclaration() )*
+  LocalVariableDeclaration() ( LOOKAHEAD(2) ";" LocalVariableDeclaration() )* [ ";" ]
 }
 
 void Identifier() :

--- a/src/main/javacc/Java1.1.jj
+++ b/src/main/javacc/Java1.1.jj
@@ -2569,7 +2569,7 @@ void PrimarySuffix() :
 |
   "::" Identifier()
 |
-  Arguments()
+  Arguments() [ "{" MethodDeclaration() "}"]
 }
 
 void Literal() :

--- a/src/main/javacc/Java1.1.jj
+++ b/src/main/javacc/Java1.1.jj
@@ -209,6 +209,7 @@ public class JavaParser implements JavaParserInterface
      public static final int TRANSIENT = 0x0100;
      public static final int VOLATILE = 0x0200;
      public static final int STRICTFP = 0x1000;
+     public static final int DEFAULT = 0x2000;
 
      /** A set of accessors that indicate whether the specified modifier
          is in the set. */
@@ -226,6 +227,11 @@ public class JavaParser implements JavaParserInterface
      public boolean isPrivate(int modifiers)
      {
        return (modifiers & PRIVATE) != 0;
+     }
+
+     public boolean isDefault(int modifiers)
+     {
+       return (modifiers & DEFAULT) != 0;
      }
 
      public boolean isStatic(int modifiers)
@@ -276,6 +282,36 @@ public class JavaParser implements JavaParserInterface
         return modifiers & ~mod;
      }
    }
+
+  public static void main(String args[]) {
+    JavaParser parser;
+    if (args.length == 0) {
+      System.out.println("Java Parser Version 1.1:  Reading from standard input . . .");
+      parser = new JavaParser(System.in);
+    } else if (args.length == 1) {
+      System.out.println("Java Parser Version 1.1:  Reading from file " + args[0] + " . . .");
+      try {
+        parser = new JavaParser(new java.io.FileInputStream(args[0]));
+      } catch (java.io.FileNotFoundException e) {
+        System.out.println("Java Parser Version 1.1:  File " + args[0] + " not found.");
+        return;
+      }
+    } else {
+      System.out.println("Java Parser Version 1.1:  Usage is one of:");
+      System.out.println("         java javancss.parser.JavaParser < inputfile");
+      System.out.println("OR");
+      System.out.println("         java javancss.parser.JavaParser inputfile");
+      return;
+    }
+    try {
+      parser.CompilationUnit();
+      System.out.println("Java Parser Version 1.1:  Java program parsed successfully.");
+    } catch (ParseException e) {
+      System.out.println(e.getMessage());
+      System.out.println("Java Parser Version 1.1:  Encountered errors during parse.");
+    }
+  }
+
 }
 
 PARSER_END(JavaParser)
@@ -801,6 +837,8 @@ TOKEN :
 | < COMMA: "," >
 | < DOT: "." >
 | < AT: "@" >
+| < LAMBDA: "->" >
+| < DOUBLECOLON: "::" >
 }
 
 /* OPERATORS */
@@ -2281,7 +2319,14 @@ void Expression() :
     //System.out.println( "Expression start" );
 }
 {
+  LOOKAHEAD(LambdaExpression())  LambdaExpression()
+|
+  AssignmentExpression()
+}
 
+void AssignmentExpression() :
+{}
+{
   LOOKAHEAD( PrimaryExpression() AssignmentOperator() )
   //{ System.out.println( "Expression" ); }
   Assignment()
@@ -2472,6 +2517,8 @@ void PrimaryExpression() :
 //    { System.out.println( "Before PrimaryExpression" ); }
 }
 {
+  LOOKAHEAD(MethodReference()) MethodReference()
+|
   PrimaryPrefix() ( LOOKAHEAD(2) PrimarySuffix() )*
 }
 
@@ -2782,9 +2829,25 @@ void SwitchStatement() :
                 _localCases = 0;
         }
   "switch" "(" Expression() ")" "{"
-    ( SwitchLabel() ( BlockStatement() )* )*
+  (SwitchCase())*
   "}"
         { _ncss++;       log.finer( "_ncss++" );}
+}
+
+void SwitchCase() :
+{}
+{
+    SwitchLabel() SwitchBlockStatements()
+}
+
+void SwitchBlockStatements() :
+{}
+{
+    LOOKAHEAD(SwitchLabel()) {}
+|
+    BlockStatement() SwitchBlockStatements()
+|
+    {}
 }
 
 void SwitchLabel() :
@@ -3108,6 +3171,11 @@ int Modifiers():
       }
 }
   |
+   "default" { modifiers |= ModifierSet.DEFAULT;       if ( _tmpToken == null ) {
+            _tmpToken = getToken( 0 );
+        }
+  }
+    |
    "final" { modifiers |= ModifierSet.FINAL;       if ( _tmpToken == null ) {
        _tmpToken = getToken( 0 );
       }
@@ -3444,3 +3512,47 @@ void MemberSelector():
   "." TypeArguments() <IDENTIFIER>
 }
 
+void LambdaExpression():
+{}
+{
+   LambdaParameters() "->" LambdaBody()
+}
+
+void LambdaParameters():
+{}
+{
+   <IDENTIFIER>
+|
+   LOOKAHEAD("(" InferredFormalParameterList() ")") "(" InferredFormalParameterList() ")"
+|
+   LOOKAHEAD( [FormalParameters()] ) [FormalParameters()]
+}
+
+void InferredFormalParameterList():
+{}
+{
+   <IDENTIFIER> ( ","  <IDENTIFIER> )*
+}
+
+
+void LambdaBody():
+{}
+{
+   Expression()
+|
+   Block()
+}
+
+void MethodReference():
+{}
+{
+   "super" "::" [TypeArguments()] <IDENTIFIER>
+|
+   LOOKAHEAD( 4 ) Name() "." "super" "::" [TypeArguments()] <IDENTIFIER>
+|
+//   ClassType() "::" [TypeArguments()] "new" and ArrayType() "::" "new" is included in below
+   LOOKAHEAD(ReferenceType() "::" [TypeArguments()] ( <IDENTIFIER> | "new" )) ReferenceType() "::" [TypeArguments()] ( <IDENTIFIER> | "new" )
+|
+//   Name() "::" [TypeArguments()] <IDENTIFIER> is included in below
+   PrimaryPrefix() ( LOOKAHEAD(2) PrimarySuffix() )* "::" [TypeArguments()] <IDENTIFIER>
+}

--- a/src/main/javacc/Java1.1.jj
+++ b/src/main/javacc/Java1.1.jj
@@ -2509,6 +2509,8 @@ void CastExpression() :
   LOOKAHEAD("(" PrimitiveType())
   "(" Type() ")" UnaryExpression()
 |
+  LOOKAHEAD("(" Type() ")" LambdaExpression()) "(" Type() ")" LambdaExpression()
+|
   "(" Type() ")" UnaryExpressionNotPlusMinus()
 }
 

--- a/src/test/java/javancss/ParseTest.java
+++ b/src/test/java/javancss/ParseTest.java
@@ -56,6 +56,7 @@ public class ParseTest extends AbstractTestCase
         checkParse( 158 ); // JAVANCSS-48
         checkParse( 159 ); // default interface methods
         checkParse( 160 ); // java 8 lambda and method reference
+        checkParse( 161 ); // found by cobertura
     }
 
     private void checkParse( int testFile )

--- a/src/test/java/javancss/ParseTest.java
+++ b/src/test/java/javancss/ParseTest.java
@@ -55,7 +55,7 @@ public class ParseTest extends AbstractTestCase
         checkParse( 157 ); // Java 7 literals
         checkParse( 158 ); // JAVANCSS-48
         checkParse( 159 ); // default interface methods
-        checkParse( 160 ); // method references
+        checkParse( 160 ); // java 8 lambda and method reference
     }
 
     private void checkParse( int testFile )

--- a/src/test/resources/Test148.java
+++ b/src/test/resources/Test148.java
@@ -33,6 +33,23 @@ public class ClassJava7 {
 		// do nothing
 	}
   }
+
+  public void baz2() {
+	String zipFileName = "";
+	String outputFileName = "";
+	java.nio.charset.Charset charset = java.nio.charset.Charset.forName("US-ASCII");
+    java.nio.file.Path outputFilePath = java.nio.file.Paths.get(outputFileName);
+	
+	try (
+      java.util.zip.ZipFile zf = new java.util.zip.ZipFile(zipFileName);
+      java.io.BufferedWriter writer = java.nio.file.Files.newBufferedWriter(outputFilePath, charset);
+    ) {
+		// do nothing
+	}
+	catch (java.beans.PropertyVetoException e) {
+		// do nothing
+	}
+  }
   
 }
 

--- a/src/test/resources/Test160.java
+++ b/src/test/resources/Test160.java
@@ -134,6 +134,8 @@ public class LamdasAndMethodRefs {
         }).map(String::toUpperCase).sorted().forEach(
                  System.out::println);
 
+	Runnable runnable = (Runnable)() -> System.out.println("Test");
+
     }
 
 }

--- a/src/test/resources/Test160.java
+++ b/src/test/resources/Test160.java
@@ -1,14 +1,139 @@
-package foobar;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.IntBinaryOperator;
+import java.util.function.IntFunction;
+import java.util.function.IntSupplier;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+import java.util.function.ToIntFunction;
+import java.util.function.UnaryOperator;
 
-public class MethodReferencesTest {
+class MyList<E> extends ArrayList<E> {
 
-    public static void main(String args[]) {
-        List<String> list = new ArrayList<>();
-
-        list.add("A");
-        list.add("B");
-        list.add("C");
-
-        list.forEach(System.out::println);
+    public MyList replaceAll2(UnaryOperator<E> operator) {
+        return this;
     }
+}
+
+class T {
+
+    public void tvarMember() {
+    }
+}
+
+class Foo {
+
+    public void bar() {
+    }
+
+    static class Bar {
+    }
+
+}
+
+class R<A> {
+
+    R() {
+    }
+
+    R(Integer a) {
+    }
+
+    R(String a) {
+    }
+}
+
+public class LamdasAndMethodRefs {
+
+    public LamdasAndMethodRefs() {
+        //Method references
+        Runnable a = super::toString;
+        Runnable b = LamdasAndMethodRefs.super::toString;
+    }
+
+    public static void main(String[] args) {
+        //Method references
+        LongSupplier a = System::currentTimeMillis; // static method
+        ToIntFunction<String> b = String::length;             // instance method
+        ToIntFunction<List> c = List::size;
+        ToIntFunction<List<String>> d = List<String>::size;  // explicit type arguments for generic type
+        UnaryOperator<int[]> e = int[]::clone;
+        Consumer<T> f = T::tvarMember;
+
+        Runnable g = System.out::println;
+        Consumer<Integer> h = String::valueOf; // overload resolution needed
+        IntSupplier i = "abc"::length;
+        Consumer<int[]> j = Arrays::sort;          // type arguments inferred from context
+        Consumer<String[]> k = Arrays::<String>sort;          // explicit type arguments
+        Supplier<ArrayList<String>> l = ArrayList<String>::new;     // constructor for parameterized type
+        Supplier<ArrayList> m = ArrayList::new;             // inferred type arguments
+        IntFunction<int[]> n = int[]::new;                 // array creation
+        Supplier<Foo> o = Foo::<Integer>new; // explicit type arguments
+        Supplier<Foo.Bar> p = Foo.Bar::new;           // inner class constructor
+        Supplier<R<String>> q = R<String>::<Integer>new;  // generic class, generic constructor
+
+        Foo[] foo = new Foo[2];
+        int r = 1;
+        foo[r] = new Foo();
+        Runnable s = foo[r]::bar;
+        boolean test = false;
+        MyList<String> list = new MyList<>();
+        Supplier<Iterator<String>> fun = (test ? list.replaceAll2(String::trim) : list)::iterator;
+
+        // Lamdas
+        Runnable t = () -> {
+        }; // No parameters; result is void
+        IntSupplier u = () -> 42; // No parameters, expression body
+        Supplier<Object> v = () -> null; // No parameters, expression body
+        v = () -> {
+            return 42;
+        }; // No parameters, block body with return
+        t = () -> {
+            System.gc();
+        }; // No parameters, void block body
+        v = () -> {                 // Complex block body with returns
+            if (true) {
+                return 12;
+            }
+            else {
+                int result = 15;
+                for (int i2 = 1; i2 < 10; i2++) {
+                    result *= i2;
+                }
+                return result;
+            }
+        };
+        IntFunction<Integer> w = (int x) -> x + 1; // Single declared-type parameter
+        w = (int x) -> {
+            return x + 1;
+        }; // Single declared-type parameter
+        w = (x) -> x + 1; // Single inferred-type parameter
+        w = x -> x + 1; // Parentheses optional for
+                // single inferred-type parameter
+        Function<String, Integer> z = (String s2) -> s2.length(); // Single declared-type parameter
+        Consumer<Thread> a2 = (Thread t2) -> {
+            t2.start();
+        }; // Single declared-type parameter
+        z = s3 -> s3.length(); // Single inferred-type parameter
+        a2 = t3 -> {
+            t3.start();
+        }; // Single inferred-type parameter
+        IntBinaryOperator b2 = (int x, int y) -> x + y; // Multiple declared-type parameters
+        b2 = (x, y) -> x + y; // Multiple inferred-type parameters
+
+        List<String> myList
+                = Arrays.asList("a1", "a2", "b1", "c2", "c1");
+
+        myList.stream().filter((s4) -> {
+            System.out.println("filter " + s4);
+            return s4.startsWith("c");
+        }).map(String::toUpperCase).sorted().forEach(
+                 System.out::println);
+
+    }
+
 }

--- a/src/test/resources/Test161.java
+++ b/src/test/resources/Test161.java
@@ -1,0 +1,21 @@
+
+ package mypackage;
+ 
+ public class FooMain {
+ public class Outer {
+   private Inner inner;
+   public Outer() {
+     inner = this.new Inner() {
+       @Override
+       public int getI() {
+         return 15;
+       }
+     };
+   }
+   private class Inner {
+     public int getI() {
+       return 1;
+     }
+   }
+ }
+ }


### PR DESCRIPTION
This PR adds Java 7 default method for interface and Java 8 lambdas and method references with tests, plus a fix and a test previously found by Cobertura.

These changes are almost the same as codehaus/javancss#3 (cherry-picked commits with minor adjustments as this repo is ahead of codehaus/javancss:master).